### PR TITLE
Fix Three.js CDN import to prevent internal server error

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -1,5 +1,5 @@
 // Modern WebGL Demo Scene Engine
-import * as THREE from 'https://cdn.skypack.dev/three@0.157.0';
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.157.0/build/three.module.js';
 import { TextEffect } from './textEffect.js';
 import { AudioAnalyzer } from './audioAnalyzer.js';
 class DemoScene {


### PR DESCRIPTION
Switched the Three.js import from Skypack to jsDelivr to avoid a 500 error. The new import uses the jsDelivr CDN which is known to be more reliable. This change ensures that the demo scene loads correctly without issues related to the CDN failing. 



Created with [**Solver**](https://solverai.com)