### PR TITLE
fix: update Three.js imports to correct CDN URLs

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -1,5 +1,5 @@
 // Modern WebGL Demo Scene Engine
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.157.0/build/three.module.js';
+import * as THREE from 'https://cdn.skypack.dev/three@0.157.0?min';
 import { TextEffect } from './textEffect.js';
 import { AudioAnalyzer } from './audioAnalyzer.js';
 class DemoScene {

--- a/js/textEffect.js
+++ b/js/textEffect.js
@@ -1,5 +1,5 @@
 // Retro Text Effect with Scanlines and Glow
-import * as THREE from 'https://cdn.skypack.dev/three@0.157.0';
+import * as THREE from 'https://cdn.skypack.dev/three@0.157.0?min';
 
 export class TextEffect {
     constructor(scene, text = "DEMO SCENE 2024") {


### PR DESCRIPTION
Fixed the Three.js import URLs to use the correct Skypack CDN format with `?min` for minimization. This change resolves the 500 Internal Server Error when attempting to load Three.js. Updated both `textEffect.js` and `demo.js` for consistency and to ensure proper functionality.



Created with [**Solver**](https://solverai.com)