### PR TITLE
Fix module import error by updating Three.js specifier

### DIFF
--- a/js/retroStereo.js
+++ b/js/retroStereo.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://unpkg.com/three@0.157.0/build/three.module.js';
 
 export class RetroStereo {
     constructor() {


### PR DESCRIPTION
This PR resolves the 'Uncaught TypeError' due to an incorrect module specifier in `js/retroStereo.js`. Changed the import statement to use the full URL like in other files such as `js/demo.js`. Now it should import Three.js correctly. This fix will prevent runtime errors and ensure the application runs smoothly.



Created with [**Solver**](https://solverai.com)