### PR TITLE
Position RetroStereo Display in Lower Left Corner

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -32,8 +32,12 @@ class DemoScene {
     }
     
     async initEffects() {
-        // Create and add the retro stereo display
+        // Create and add the retro stereo display in lower left corner
         this.retroStereo = new RetroStereo();
+        // Position in lower left corner
+        this.retroStereo.group.position.set(-1.5, -1, -2);
+        // Rotate slightly for better visibility
+        this.retroStereo.group.rotation.set(0, Math.PI * 0.15, 0);
         this.scene.add(this.retroStereo.group);
 
         // Create a retro-style tunnel effect

--- a/js/retroStereo.js
+++ b/js/retroStereo.js
@@ -4,8 +4,6 @@ export class RetroStereo {
     constructor() {
         // Create main group for the stereo
         this.group = new THREE.Group();
-        this.group.position.set(0, 1.5, -3);
-        this.group.rotation.x = -0.2;
 
         // Create stereo frame
         const frame = new THREE.Mesh(


### PR DESCRIPTION
Updated the RetroStereo display position to the lower left corner of the scene. Removed default positions from the RetroStereo class constructor for better flexibility. Added custom positioning and rotation in demo.js for optimal visibility. Ensured the oscilloscope, spectrum analyzer, and info display are all well-placed.



Created with [**Solver**](https://solverai.com)